### PR TITLE
Lint, cleanup, fmt, clippy, 2021 edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 /nogit
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,13 @@
 name = "viperus"
 version = "0.1.11"
 authors = ["mauro cordioli <coma@cordioli.it>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/maurocordioli/viperus"
-description="Viperus is an  (in)complete configuration solution for rust applications heavly inspired by the GO package Viper.It supports defaults reading from JSON, TOML, YAML, envfile,java properties, environment variables reading from Clap command line flags setting explicit values"
+description = "Viperus is an  (in)complete configuration solution for rust applications heavly inspired by the GO package Viper.It supports defaults reading from JSON, TOML, YAML, envfile,java properties, environment variables reading from Clap command line flags setting explicit values"
 exclude = ["tarpaulin-report.html"]
-keywords= ["config", "yaml", "toml", "json", "dotenv"]
-readme="README.md"
+keywords = ["config", "yaml", "toml", "json", "dotenv"]
+readme = "README.md"
 
 [badges]
 
@@ -44,22 +44,22 @@ maintenance = { status = "experimental" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log="0.4"
-serde={ version="1.0.0", optional=true}
-serde_yaml={ version="0.8.11", optional=true} 
-serde_json={ version="1.0.44", optional=true}
-clap={ version="2.33.0", optional=true}
+log = "0.4"
+serde = { version = "1.0.0", optional = true }
+serde_yaml = { version = "0.8.11", optional = true }
+serde_json = { version = "1.0.44", optional = true }
+clap = { version = "2.34.0", optional = true }
 
-dotenv={ version="0.15.0", optional=true}
-toml= { version="0.5.5", optional=true}
-java-properties = { version="1.2.0", optional=true}
- 
-lazy_static= { version="1.4.0", optional=true}
-notify = { version="4.0.0", optional=true}
+dotenv = { version = "0.15.0", optional = true }
+toml = { version = "0.5.5", optional = true }
+java-properties = { version = "1.4.0", optional = true }
 
-[dev-dependencies] 
-env_logger = "0.7.1"
-tempfile = "3.1.0"
+lazy_static = { version = "1.4.0", optional = true }
+notify = { version = "4.0.0", optional = true }
+
+[dev-dependencies]
+env_logger = "0.9"
+tempfile = "3.3.0"
 criterion = "0.3.0"
 
 [[bench]]
@@ -75,15 +75,15 @@ default = ["cache", "global", "fmt-clap", "fmt-env", "fmt-javaproperties", "fmt-
 global = ["lazy_static"]
 
 # cache queries
-cache =[]
+cache = []
 
 # triggers parameter changes in config files
-watch=["global", "notify"]
+watch = ["global", "notify"]
 
 # supported format parsers
-fmt-clap=["clap"]
-fmt-env=["dotenv"]
-fmt-javaproperties=["java-properties"]
-fmt-json=["serde","serde_json"]
-fmt-toml=[ "toml"]
-fmt-yaml=["serde","serde_yaml"]
+fmt-clap = ["clap"]
+fmt-env = ["dotenv"]
+fmt-javaproperties = ["java-properties"]
+fmt-json = ["serde", "serde_json"]
+fmt-toml = ["toml"]
+fmt-yaml = ["serde", "serde_yaml"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
  ~~go~~  rust configuration with fangs!
 
 `viperus` is an (in)complete commandline configuration solution for Rust applications.
-It is heavly inspired by the wonderful go package <https://github.com/spf13/viper>
+It is heavily inspired by the wonderful go package <https://github.com/spf13/viper>
 Use it at your own risk. ;-)
 
 no Go projects ~~has been harmed~~ are built consuming `viperus` :-)
@@ -14,14 +14,14 @@ no Go projects ~~has been harmed~~ are built consuming `viperus` :-)
 * 0.1.5  add watch_all files with autoreload
 * 0.1.4  add format: java properties files
 * 0.1.3  better clap args: default values
-* 0.1.2  relaod config from files
+* 0.1.2  reload config from files
 * 0.1.1  fixes dcs
 * 0.1.0  first release
 
 ## What is viperus?
 Viperus is a package, that enables program configuration via an extendable
-types system. Parameters can be incoprorated via cli parameters, environment
-viariables. Parameters may be declared in configuration files as well.
+types system. Parameters can be incorporated via cli parameters, environment
+variables. Parameters may be declared in configuration files as well.
 
 Given implementation can handle:
 
@@ -37,7 +37,7 @@ Given implementation can handle:
 
 ## Why viperus?
 
-beacuse I was migrating some go apps ... and there was missing a rust tool that supplies `Viper` ease of use :-)
+because I was migrating some go apps ... and there was missing a rust tool that supplies `Viper` ease of use :-)
 
 When config parameters are applied, Viperus uses the following decreasing precedence order:
 
@@ -49,7 +49,7 @@ When config parameters are applied, Viperus uses the following decreasing preced
 
 `viperus` merges configuration parameters from
 
- * clap optoins
+ * clap options
  * dotenv
  * json files
  * toml files
@@ -58,8 +58,8 @@ When config parameters are applied, Viperus uses the following decreasing preced
 in a single typed hash structure. The structure can be preset with default. Values are type checked.
 
 You can create a standalone `viperus` object or "enjoy" a global
-instance. The global instance is guarded with a Mutex to garantee
-thread safty.
+instance. The global instance is guarded with a Mutex to guarantee
+thread safety.
 
 Structure elements of a static instance may be manipulated via the shadow functions
 
@@ -69,7 +69,7 @@ Structure elements of a static instance may be manipulated via the shadow functi
  * load_file
 
 ```rust
-// add a dotenv config file. keys defautls to the env variables
+// add a dotenv config file. keys defaults to the env variables
 viperus::load_file(".env", viperus::Format::ENV).unwrap();
 
 // add another file
@@ -88,7 +88,7 @@ viperus::cache(true);
 let ok=viperus::get::<bool>("TEST_BOOL").unwrap();
 ```
 
-** Sidenote:  Yes I konw globals are evil. Inspiration was taken form the go package `viper` that is taking this route ....
+** Side note:  Yes I know globals are evil. Inspiration was taken form the go package `viper` that is taking this route ....
 If you dislike globals, or other preset defaults, go ahead and opt-out like this:
 
 ```cargo
@@ -104,7 +104,7 @@ Cache is only thread safe if you use a global instance that is guarded with an a
 ```
 
 The caching is invalidated, if you
- * reload any file with an excplicit ``` viperus::reload() ```
+ * reload any file with an explicit ``` viperus::reload() ```
  * parameter changes inside a file, that is observed with the  `watch` feature
 
 ## logging/debug
@@ -122,7 +122,7 @@ The crate may be adopted using cargo's "feature" semantic. The default enables a
 *  feature = "watch" enabling the automatic file reload ( prerequisite: feature=global)
 *  feature = "cache" enabling caching
 
-single featues could be activated in a selective way  via cargo.toml
+single feature could be activated in a selective way via cargo.toml
 
 ```toml
 [dependencies.viperus]
@@ -132,14 +132,14 @@ version = "0.1.8"
 default-features = false
 
 # cherry-pick individual features
-features = ["global", "cache","watch","fmt-yaml"]
+features = ["global", "cache", "watch", "fmt-yaml"]
 ```
 
 ## Tests
 All available integration tests are put into the subdirectory `tests`.
 Reading the source code may help to get into the inner logic.
 
-```
+```bash
 cargo test
 ```
 
@@ -149,7 +149,7 @@ Inside the example subdirectory there is a reference implementation that consume
 
 Compile and execute it like this:
 
-```
+```bash
 cargo run --example cli-clap-yaml --
 ```
 
@@ -158,7 +158,7 @@ arguments, the revealed parameters inside the config file will be parsed out.
 
 In a second run, we call this example providing commandline parameters:
 
-```
+```bash
 cargo run --example cli-clap-yaml -- -c ./example.conf -u http://nowhere/api/v1
 ```
 
@@ -166,6 +166,9 @@ Since the `cli-clap-yaml` does call **with** commandline
 arguments, the revealed parameters inside the config file are overwritten.
 
 ```rust
+use clap::{App, Arg};
+use log::debug;
+use viperus::{path, Format, Viperus};
 
 let matches = App::new("My Super Program")
 				 .arg(Arg::with_name("v")
@@ -178,24 +181,24 @@ let mut v = Viperus::new();
 //enable clap
 v.load_clap(matches);
 //enable a yaml json toml file
-v.load_file(&path!(".","assets","test.yaml"), Format::YAML).unwrap();
-v.load_file(&path!(".","assets","test.json"), Format::JSON).unwrap();
-v.load_file(&path!(".","assets","test.toml"), Format::TOML).unwrap();
-v.load_file(&path!(".","assets","test.properties"), Format::JAVAPROPERTIES).unwrap();
+v.load_file(&path!(".", "assets", "test.yaml"), Format::YAML).unwrap();
+v.load_file(&path!(".", "assets", "test.json"), Format::JSON).unwrap();
+v.load_file(&path!(".", "assets", "test.toml"), Format::TOML).unwrap();
+v.load_file(&path!(".", "assets", "test.properties"), Format::JAVAPROPERTIES).unwrap();
 //link the "v" clap option to the key "verbose"
-v.bond_clap("v","verbose");
+v.bond_clap("v", "verbose");
 
 
 //add an explicit overload
-v.add("service.url", String::from("http://example.com"));
+v.add("service.url", String::from("https://example.com"));
 debug!("final {:?}", v);
 
 //get a typed key
 let s: &str = v.get("service.url").unwrap();
-assert_eq!("http://example.com", s);
+assert_eq!("https://example.com", s);
 
 //get a bool from configs or app args
-let fVerbose=v.get::<bool>("verbose").unwrap();
+let fVerbose = v.get::<bool>("verbose").unwrap();
 assert_eq!(true, fVerbose);
 ```
 

--- a/examples/cli-clap-yaml.rs
+++ b/examples/cli-clap-yaml.rs
@@ -39,19 +39,18 @@ fn main() {
     #[cfg(feature = "fmt-yaml")]
     {
         println!("Feature: `fmt-yml`, parsing ...");
-    viperus::load_file(&path!("examples", "example.yaml"), viperus::Format::YAML).unwrap();
+        viperus::load_file(&path!("examples", "example.yaml"), viperus::Format::YAML).unwrap();
 
         println!("Parsed parameters:");
-        println!(" - config: {}",
-                 viperus::get::<String>("config.file").unwrap()
+        println!(
+            " - config: {}",
+            viperus::get::<String>("config.file").unwrap()
         );
-        println!(" - url: {}",
-        viperus::get::<String>("service.url").unwrap()
-    );
+        println!(" - url: {}", viperus::get::<String>("service.url").unwrap());
     }
 }
 
 #[cfg(not(all(feature = "global", feature = "fmt-clap")))]
 fn main() {
-    println!("Viperus: opted out feature `global`, `fmt-clap`" );
+    println!("Viperus: opted out feature `global`, `fmt-clap`");
 }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -24,9 +24,9 @@ pub use ayaml::*;
 
 /// ConfigAdapter mediates from varius config format and Viperus
 pub trait ConfigAdapter {
-    /// parse create he interna rappresentation of the config file/mode
+    /// parse create he internal presentation of the config file/mode
     fn parse(&mut self) -> AdapterResult<()>;
-    /// get_map returns a key value map rappresentation of the actaul config
+    /// get_map returns a key value map presentation of the actual config
     fn get_map(&self) -> crate::map::Map;
 }
 

--- a/src/adapter/aenv.rs
+++ b/src/adapter/aenv.rs
@@ -29,6 +29,7 @@ impl EnvAdapter {
         &self.real_path
     }
 }
+
 impl ConfigAdapter for EnvAdapter {
     fn parse(&mut self) -> AdapterResult<()> {
         self.data = dotenv::vars().collect();

--- a/src/adapter/ajson.rs
+++ b/src/adapter/ajson.rs
@@ -1,4 +1,5 @@
 use super::*;
+use log::debug;
 
 /// JsonAdapter map a Json file in a linear multilevel key/value array
 ///

--- a/src/adapter/aprop.rs
+++ b/src/adapter/aprop.rs
@@ -4,7 +4,7 @@ use java_properties::PropertiesIter;
 
 use std::io::BufReader;
 
-/// JPropertiesAdapter map a ajava properties file in a linear multilevel key/value array
+/// JPropertiesAdapter map a java properties file in a linear multilevel key/value array
 ///
 /// the adaptor could be consumed by Viperous
 /// internally uses java_properties crate

--- a/src/adapter/atoml.rs
+++ b/src/adapter/atoml.rs
@@ -1,5 +1,5 @@
 use super::*;
-use toml;
+use log::debug;
 
 /// TomlAdapter map a Toml file in a linear multilevel key/value array
 ///

--- a/src/adapter/ayaml.rs
+++ b/src/adapter/ayaml.rs
@@ -1,9 +1,9 @@
 use super::*;
-use serde_yaml;
+use log::debug;
 
 /// YamlAdapter map a Yaml file in a linear multilevel key/value array
 ///
-/// the adaptor could be consumed by Viperous  
+/// the adaptor could be consumed by Viperous
 pub struct YamlAdapter {
     source: String,
     data: serde_yaml::Mapping,
@@ -50,7 +50,7 @@ impl ConfigAdapter for YamlAdapter {
             if let serde_yaml::Value::String(s) = k {
                 let kpath = s.to_owned();
 
-                rec_yaml(&mut res, &kpath, &v);
+                rec_yaml(&mut res, &kpath, v);
             }
         }
 

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,6 +1,6 @@
 //! all the stuff that create a global instance of viperus
 //!
-//! the instance is "lazy_static" and proteced by a mutex
+//! the instance is "lazy_static" and protected by a mutex
 
 use super::*;
 use std::sync::mpsc::channel;
@@ -9,11 +9,12 @@ use std::sync::mpsc::channel;
 use notify::Watcher;
 use std::time::Duration;
 
+use log::{error, info};
 use std::sync::Arc;
 use std::sync::Mutex;
 
 #[cfg(feature = "global")]
-lazy_static! {
+lazy_static::lazy_static! {
     /// the global instance
     static ref VIPERUS: Arc::<Mutex::<Viperus<'static>>> = Arc::new(Mutex::new(Viperus::new()));
 }
@@ -65,56 +66,57 @@ pub fn load_file(name: &str, format: Format) -> Result<(), Box<dyn Error>> {
     VIPERUS.lock().unwrap().load_file(name, format)
 }
 
-/// load_adapter ask the adapter to parse her data and merges result map in the internal configurtion map of global instance
-pub fn load_adapter(adt: &mut dyn adapter::ConfigAdapter) -> Result<(), Box<dyn Error>> {
+/// load_adapter ask the adapter to parse her data and merges result
+/// map in the internal configuration map of global instance
+pub fn load_adapter(adt: &mut dyn ConfigAdapter) -> Result<(), Box<dyn Error>> {
     VIPERUS.lock().unwrap().load_adapter(adt)
 }
 
-/// add an override value to the cofiguration
+/// add an override value to the configuration
 ///
 /// key is structured in components separated by a "."
 pub fn add<T>(key: &str, value: T) -> Option<T>
 where
-    map::ViperusValue: From<T>,
-    map::ViperusValue: Into<T>,
+    ViperusValue: From<T>,
+    ViperusValue: Into<T>,
 {
     VIPERUS.lock().unwrap().add(key, value)
 }
 
 /// get a configuration value of type T from global configuration in this order
-/// * overrided key
+/// * overridden key
 /// * clap parameters
 /// * config adapter sourced values
 /// * default value
 pub fn get<'a, 'b, T>(key: &'a str) -> Option<T>
 where
-    map::ViperusValue: From<T>,
-    &'b map::ViperusValue: Into<T>,
-    map::ViperusValue: Into<T>,
+    ViperusValue: From<T>,
+    &'b ViperusValue: Into<T>,
+    ViperusValue: Into<T>,
     T: FromStr,
     T: Clone,
 {
     VIPERUS.lock().unwrap().get(key)
 }
 
-/// add an default value to the global cofiguration
+/// add an default value to the global configuration
 ///
 /// key is structured in components separated by a "."
 pub fn add_default<T>(key: &str, value: T) -> Option<T>
 where
-    map::ViperusValue: From<T>,
-    map::ViperusValue: Into<T>,
+    ViperusValue: From<T>,
+    ViperusValue: Into<T>,
 {
     VIPERUS.lock().unwrap().add_default(key, value)
 }
 
-///load_clap  brings in  the clap magic
+/// load_clap  brings in  the clap magic
 #[cfg(feature = "fmt-clap")]
 pub fn load_clap(matches: clap::ArgMatches<'static>) -> Result<(), Box<dyn Error>> {
     VIPERUS.lock().unwrap().load_clap(matches)
 }
 
-/// bond a clap argsument to a config key
+/// bond a clap argument to a config key
 #[cfg(feature = "fmt-clap")]
 pub fn bond_clap(src: &str, dst: &str) -> Option<String> {
     VIPERUS.lock().unwrap().bond_clap(src, dst)
@@ -126,20 +128,20 @@ pub fn reload() -> Result<(), Box<dyn Error>> {
 }
 
 /// cache the query results for small configs speedup is x4
-///from v 0.1.9 returns the previus state , useful for test setups.
+/// from v0.1.9 returns the previous state, useful for test setups.
 #[cfg(feature = "cache")]
 pub fn cache(enable: bool) -> bool {
     VIPERUS.lock().unwrap().cache(enable)
 }
 
-/// whan enabled viperus will check for an environment variable any time Get request is made
-/// checking  for a environment variable with a name matching the key uppercased and prefixed with the
+/// when enabled viperus will check for an environment variable any time Get request is made
+/// checking  for a environment variable with a name matching the upper-cased key and prefixed with the
 /// env_prefix if set.
 pub fn automatic_env(enable: bool) {
     VIPERUS.lock().unwrap().automatic_env(enable)
 }
 
-/// prepend 'pefix' when quering envirment variables
+/// prepend 'prefix' when querying environment variables
 pub fn set_env_prefix(prefix: &str) {
     VIPERUS.lock().unwrap().set_env_prefix(prefix)
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -22,8 +22,8 @@ impl Map {
         }
     }
 
-    pub fn drain<'a>(&'a mut self) -> Drain<'a, String, ViperusValue> {
-      self.data.drain()
+    pub fn drain(&mut self) -> Drain<String, ViperusValue> {
+        self.data.drain()
     }
 
     pub fn add<T>(&mut self, key: &str, value: T) -> Option<T>
@@ -31,10 +31,9 @@ impl Map {
         ViperusValue: From<T>,
         ViperusValue: Into<T>,
     {
-        match self.data.insert(key.to_string(), ViperusValue::from(value)) {
-            None => None,
-            Some(mv) => Some(mv.into()),
-        }
+        self.data
+            .insert(key.to_string(), ViperusValue::from(value))
+            .map(|mv| mv.into())
     }
 
     pub fn add_value(&mut self, key: &str, value: ViperusValue) -> Option<ViperusValue> {
@@ -63,13 +62,10 @@ impl Map {
         &'c ViperusValue: Into<T>,
         ViperusValue: Into<T>,
     {
-        match self.data.get(key) {
-            None => None,
-            Some(mv) => Some((*mv).clone().into()),
-        }
+        self.data.get(key).map(|mv| (*mv).clone().into())
     }
 
-    pub fn merge(&mut self, src: &Map)  {
+    pub fn merge(&mut self, src: &Map) {
         for (k, v) in &src.data {
             self.add_value(k, v.clone());
         }
@@ -87,7 +83,7 @@ mod tests {
         let mv1 = m.get_value("test.value").unwrap();
         if let ViperusValue::I32(v1) = mv1 {
             assert_eq!(10, *v1);
-        }  
+        }
     }
 
     #[test]
@@ -97,10 +93,10 @@ mod tests {
 
         let mv0 = m.add_value("test.value", ViperusValue::from(42));
         assert_eq!(None, mv0);
-      
+
         let _a1 = m.add::<i32>("test.value_i32", 314).unwrap_or_default();
         let _a2 = m.add::<i32>("test.value_i32", 314).unwrap_or_default();
-        
+
         let v1 = m.get::<i32>("test.value").unwrap();
         assert_eq!(42, v1);
 

--- a/src/map/map_value.rs
+++ b/src/map/map_value.rs
@@ -1,6 +1,6 @@
-///ViperusValue encaspule data values of type String,i32 and bool
+/// ViperusValue encapsulate data values of type String,i32 and bool
 ///
-///implements bidirectional conversion to respective  values via Into<T> and From<T>
+/// implements bidirectional conversion to respective  values via Into<T> and From<T>
 /// # Example
 /// ```
 /// use viperus::ViperusValue;
@@ -18,8 +18,8 @@ pub enum ViperusValue {
 impl Into<bool> for &ViperusValue {
     fn into(self) -> bool {
         match self {
-        ViperusValue::BOOL(i) => *i,
-        ViperusValue::Str(s) => s.parse().expect("not a bool"),
+            ViperusValue::BOOL(i) => *i,
+            ViperusValue::Str(s) => s.parse().expect("not a bool"),
             _ => panic!("not a bool"),
         }
     }
@@ -28,8 +28,8 @@ impl Into<bool> for &ViperusValue {
 impl Into<bool> for ViperusValue {
     fn into(self) -> bool {
         match self {
-        ViperusValue::BOOL(i) => i,
-        ViperusValue::Str(s) => s.parse().expect("not a bool"),
+            ViperusValue::BOOL(i) => i,
+            ViperusValue::Str(s) => s.parse().expect("not a bool"),
 
             _ => panic!("not a bool {:?}", self),
         }
@@ -62,7 +62,7 @@ impl Into<i32> for ViperusValue {
     fn into(self) -> i32 {
         match self {
             ViperusValue::I32(i) => i,
-           
+
             ViperusValue::Str(s) => s.parse().expect("not an i32"),
             _ => panic!("not an i32"),
         }
@@ -89,8 +89,8 @@ impl From<&str> for ViperusValue {
 
 impl<'a> Into<&'a str> for &'a ViperusValue {
     fn into(self) -> &'a str {
-        match self { 
-        ViperusValue::Str(i) => i,
+        match self {
+            ViperusValue::Str(i) => i,
             _ => panic!("not an str"),
         }
     }
@@ -99,7 +99,7 @@ impl<'a> Into<&'a str> for &'a ViperusValue {
 impl<'a> Into<String> for &'a ViperusValue {
     fn into(self) -> String {
         match self {
-        ViperusValue::Str(i) => i.clone(),
+            ViperusValue::Str(i) => i.clone(),
             _ => panic!("not an str"),
         }
     }
@@ -107,8 +107,8 @@ impl<'a> Into<String> for &'a ViperusValue {
 
 impl Into<String> for ViperusValue {
     fn into(self) -> String {
-        match self  {
-        ViperusValue::Str(i) => i,
+        match self {
+            ViperusValue::Str(i) => i,
             _ => panic!("not a string"),
         }
     }
@@ -163,13 +163,13 @@ mod tests {
 
         let mv = ViperusValue::from("hello world!");
         match mv {
-        ViperusValue::Str(s) =>  assert_eq!(s, "hello world!"),
-        _ => panic!("something very wrong"),
+            ViperusValue::Str(s) => assert_eq!(s, "hello world!"),
+            _ => panic!("something very wrong"),
         }
 
         let refmv = ViperusValue::from(&("hello world!".to_owned()));
         match refmv {
-        ViperusValue::Str(s) => assert_eq!(s, "hello world!"),
+            ViperusValue::Str(s) => assert_eq!(s, "hello world!"),
             _ => panic!("something very wrong"),
         }
     }

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -38,7 +38,7 @@ fn test_global() {
     assert_ne!(viperus::get::<bool>("default").unwrap(), true);
 }
 
-/// a mockup adapter for testonly
+/// a mockup adapter for test only
 struct ZeroAdapter {}
 impl viperus::ConfigAdapter for ZeroAdapter {
     fn parse(&mut self) -> viperus::AdapterResult<()> {

--- a/tests/watch.rs
+++ b/tests/watch.rs
@@ -1,10 +1,6 @@
-#[macro_use]
-extern crate log;
-extern crate tempfile;
-extern crate viperus;
-use std::io::Write;
-
+use log::debug;
 use std::fs::File;
+use std::io::Write;
 
 fn init() {
     let _ = env_logger::builder().is_test(true).try_init();


### PR DESCRIPTION
A few minor cleanups to make it easier to submit PRs:
* migrate to 2021 edition
* run `cargo fmt`
* bump some dependencies to their latest
  * Note that Clap is locked to 2.x until https://github.com/clap-rs/clap/issues/1206 is fixed in v4 (?)
* spelling fixes

TODO for another PR:
* fix many clippy [from_over_into](https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into) warnings in the src/map/map_value.rs file.
* README.md still has a few bugs. Uncomment a section in the lib.rs to show them during the test run.